### PR TITLE
Update FFT 1: Rename to Navigating AI Together and add materials

### DIFF
--- a/templates/programs.html
+++ b/templates/programs.html
@@ -71,16 +71,15 @@
             <div class="sessions-container">
 				<div class="session-card">
 					<div class="session-header">
-						<h3>FFT 1: The AI Mismatch: Why Students and Faculty Aren't on the Same Page</h3>
+						<h3>FFT 1: Navigating AI Together</h3>
 					</div>
 					<p class="session-description">
-					Recent survey of WPI students has revealed a surprising disconnect in how students and faculty views AI in the classroom. 
-					For example, only 11% of faculty are against AI in academic contexts, compared to 30% of students.
-					This session brings students and faculty together to explore these gaps. I'll share additional findings from my baseline surveys, but the focus will be on dialogue: What do students need from us? What do we need from them? 
+					This session brought faculty and students together to discuss baseline survey results comparing their perspectives on AI use in academic settings. Key findings revealed that while adoption rates are similar across groups, one-third of students reported being against AI use compared to only 11% of faculty. The discussion explored tensions around AI policies, academic integrity, and the impact of AI on foundational learning.
 					</p>
-					<a href="https://wpi.qualtrics.com/jfe/form/SV_3CshWFIcJ87baBw" class="btn btn-primary" target="_blank">
-					Register
-					</a>
+					<div class="session-materials">
+						<a href="files/FFT01_Consolidared_Report.pdf" class="btn btn-primary" target="_blank">Summary</a>
+						<a href="files/FFT01_Navigating_AI_Together.pdf" class="btn btn-primary" target="_blank">Presentation</a>
+					</div>
 				</div>
                 
             </div>


### PR DESCRIPTION
- Renamed title from "The AI Mismatch" to "Navigating AI Together"
- Updated description based on session report
- Replaced Register button with Summary and Presentation links